### PR TITLE
replace appcast by livecheck

### DIFF
--- a/Casks/okta.rb
+++ b/Casks/okta.rb
@@ -3,7 +3,7 @@ cask 'okta' do
   sha256 '3a82e5dc6bfd7c6415706b92da8b61d04ea45d47373aece3acf7697fa3b25949'
 
   url "https://github.com/okta/okta-cli/releases/download/okta-cli-tools-#{version}/okta-cli-macos-#{version}-x86_64.zip"
-  appcast 'https://github.com/okta/okta-cli/releases.atom'
+  livecheck 'https://github.com/okta/okta-cli/releases.atom'
   name 'okta'
   homepage 'https://cli.okta.com/'
 

--- a/Casks/okta.rb
+++ b/Casks/okta.rb
@@ -3,7 +3,9 @@ cask 'okta' do
   sha256 '3a82e5dc6bfd7c6415706b92da8b61d04ea45d47373aece3acf7697fa3b25949'
 
   url "https://github.com/okta/okta-cli/releases/download/okta-cli-tools-#{version}/okta-cli-macos-#{version}-x86_64.zip"
-  livecheck 'https://github.com/okta/okta-cli/releases.atom'
+  livecheck do 
+    url 'https://github.com/okta/okta-cli/releases.atom'
+  end
   name 'okta'
   homepage 'https://cli.okta.com/'
 


### PR DESCRIPTION
Currently, upgrading brew gives: 

```
Warning: Calling the `appcast` stanza is deprecated! Use the `livecheck` stanza instead.
Please report this issue to the oktadeveloper/tap tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/oktadeveloper/homebrew-tap/Casks/okta.rb:6
```

This PR intends to fix this issue.